### PR TITLE
Get bedloadCoeffData without using Matrix worker stuff

### DIFF
--- a/gcmrc-ui/src/main/webapp/pages/reachview/page.js
+++ b/gcmrc-ui/src/main/webapp/pages/reachview/page.js
@@ -536,21 +536,15 @@ GCMRC.Page = {
 			}));
 		}
 		
-		
+		//Get special bedload coefficients for dinosaur network
 		if (CONFIG.networkName === NETWORK_DINO) {
-		    if (GCMRC.Page.reachDetail.some(function(el){return el.reachGroup === "Calc Inst Sand Bedload"})) {
-			result.push(new Budget({
-				budgetType : "bedLoadCoeff",
-				budgetColumns : budgetColumns["Calc Inst Sand Bedload"],
+			result.push({
+				groupId : "bedLoadCoeff",
+				groupName: "Discharge",
+				columns: budgetColumns["Calc Inst Sand Bedload"],
 				responseColumns : responseColumns["Calc Inst Sand Bedload"],
-				yAxisLabel : "",
-				seriesName : "",
-				reqIdName : "",
-				updateFnName : "updateBedLoad",
-				workerFedName : "isBedLoadWorkerFed",
-				workerName : "bedLoad"
-			}));
-		    }
+				yAxisLabel: ""
+			});
 		}
 		
 		return result;

--- a/gcmrc-ui/src/main/webapp/pages/reachview/page.js
+++ b/gcmrc-ui/src/main/webapp/pages/reachview/page.js
@@ -293,6 +293,7 @@ GCMRC.Page = {
 	isFinesWorkerFed: false,
 	latestSandReqId: 1,
 	latestFinesReqId: 1,
+	bedLoadCoeffData: [],
 	updateSandSummary: function(config) {
 		if (config) {
 			var upper = config.upper;
@@ -506,13 +507,46 @@ GCMRC.Page = {
 				GCMRC.Page.drawBudget(config);
 			};
 		};
+		
+		var BedloadCoeff = function() {
+			this.groupId = "bedLoadCoeff";
+			this.columns = ["inst!" + "Calc Inst Sand Bedload" + "!" + GCMRC.Page.reach.downstreamDischargeStation];
+			this.responseColumns = ["inst!" + "Calc Inst Sand Bedload" + "-" + GCMRC.Page.reach.downstreamDischargeStation];
+			this.yAxisLabel = "";
+			this.dealWithResponse = function(graphToMake, data, config, buildGraph) {
+				var self = this;
+				var coeffData = [];
+				
+				var getValue = function(row, colName) {
+					var result = 0.0;
+					if (row[colName]) {
+						result = parseFloat(row[colName]);
+					}
+					return result;
+				};
+				
+				if(!data.success){
+					return;
+				}
+
+				//Extract and store bedloadCoeffData
+				data.success.data.each(function(el) {
+					var result = 0.0;
+					if (el[self.responseColumns[0]]) {
+						result = parseFloat(el[self.responseColumns[0]]);
+					}
+					coeffData.push(result);
+				});
+				
+				GCMRC.Page.bedLoadCoeffData = coeffData;
+			};
+		};
 
 		if (GCMRC.Page.reachDetail.some(function(el){return el.reachGroup === "S Sand Cumul Load"})) {
 			result.push(new Budget({
 				budgetType : "sandbudget",
 				budgetColumns : budgetColumns["S Sand Cumul Load"],
 				responseColumns : responseColumns["S Sand Cumul Load"],
-				bedLoadCoeffColumns : responseColumns["Calc Inst Sand Bedload"],
 				yAxisLabel : "Change in Sand Stored in Reach (Metric Tons)",
 				seriesName : "Sand Storage Change",
 				reqIdName : "latestSandReqId",
@@ -538,13 +572,7 @@ GCMRC.Page = {
 		
 		//Get special bedload coefficients for dinosaur network
 		if (CONFIG.networkName === NETWORK_DINO) {
-			result.push({
-				groupId : "bedLoadCoeff",
-				groupName: "Discharge",
-				columns: budgetColumns["Calc Inst Sand Bedload"],
-				responseColumns : responseColumns["Calc Inst Sand Bedload"],
-				yAxisLabel: ""
-			});
+			result.push(new BedloadCoeff());
 		}
 		
 		return result;


### PR DESCRIPTION
Added a new method to get bedloadCoeffData and avoid going through all of the matrix worker messaging stuff and also avoid having the page attempt to plot it by overriding dealWithResponse. dealWithResponse now parses the returned bedloadCoeffData and stores it in an accessible variable at the page level: GCMRC.Page.bedLoadCoeffData (see line 296). 

Next steps would be to add a listener to the toggle switch to do the actual addition, re-feed the transformed data into the generated plot, and then re-draw the plot. 

This PR doesn't necessarily need to be merged and I'll be happy to continue working on this Monday, but I'm getting ready to head out for the weekend now and I wanted my updates to be available in case you wanted to work on it before I get in on Monday or over the weekend.